### PR TITLE
Ensure the token is always URL friendly

### DIFF
--- a/app/controllers/mailkick/subscriptions_controller.rb
+++ b/app/controllers/mailkick/subscriptions_controller.rb
@@ -7,12 +7,12 @@ module Mailkick
 
     def unsubscribe
       Mailkick.opt_out(@options)
-      redirect_to subscription_path(params[:id])
+      redirect_to subscription_path(url_token)
     end
 
     def subscribe
       Mailkick.opt_in(@options)
-      redirect_to subscription_path(params[:id])
+      redirect_to subscription_path(url_token)
     end
 
     protected
@@ -41,14 +41,20 @@ module Mailkick
     helper_method :opted_out?
 
     def subscribe_url
-      subscribe_subscription_path(params[:id])
+      subscribe_subscription_path(url_token)
     end
     helper_method :subscribe_url
 
     def unsubscribe_url
-      unsubscribe_subscription_path(params[:id])
+      unsubscribe_subscription_path(url_token)
     end
     helper_method :unsubscribe_url
+
+    private
+
+    def url_token
+      @url_token ||= CGI::escape(params[:id])
+    end
 
   end
 end

--- a/lib/mailkick/processor.rb
+++ b/lib/mailkick/processor.rb
@@ -20,7 +20,7 @@ module Mailkick
 
       parts = message.parts.any? ? message.parts : [message]
       parts.each do |part|
-        part.body.raw_source.gsub!(/%7B%7BMAILKICK_TOKEN%7D%7D/, token)
+        part.body.raw_source.gsub!(/%7B%7BMAILKICK_TOKEN%7D%7D/, CGI::escape(token))
       end
     end
 


### PR DESCRIPTION
Email addresses with a + in them were generating a token with an unescaped forward slash, which messed up the subscription links and routes for Rails apps.
