### PR TITLE
Added url unescaping when passing token to verifier.

### DIFF
--- a/app/controllers/mailkick/subscriptions_controller.rb
+++ b/app/controllers/mailkick/subscriptions_controller.rb
@@ -20,7 +20,7 @@ module Mailkick
     def set_email
       verifier = ActiveSupport::MessageVerifier.new(Mailkick.secret_token)
       begin
-        @email, user_id, user_type, @list = verifier.verify(params[:id])
+        @email, user_id, user_type, @list = verifier.verify(CGI.unescape(params[:id]))
         if user_type
           # on the unprobabilistic chance user_type is compromised, not much damage
           @user = user_type.constantize.find(user_id)


### PR DESCRIPTION
E.g. BAhbUkiHXdpbRjA%3D--c485f3cb4c65 -> BAhbUkiHXdpbRjA=--c485f3cb4c65
Was breaking and returning 'Subscription not found' as a result of '=' sign being url encoded but not decoded when being passed to verifier