### PR TITLE
Avoid double escaping token

### DIFF
--- a/app/controllers/mailkick/subscriptions_controller.rb
+++ b/app/controllers/mailkick/subscriptions_controller.rb
@@ -7,12 +7,12 @@ module Mailkick
 
     def unsubscribe
       Mailkick.opt_out(@options)
-      redirect_to subscription_path(url_token)
+      redirect_to subscription_path(params[:id])
     end
 
     def subscribe
       Mailkick.opt_in(@options)
-      redirect_to subscription_path(url_token)
+      redirect_to subscription_path(params[:id])
     end
 
     protected
@@ -41,19 +41,13 @@ module Mailkick
     helper_method :opted_out?
 
     def subscribe_url
-      subscribe_subscription_path(url_token)
+      subscribe_subscription_path(params[:id])
     end
     helper_method :subscribe_url
 
     def unsubscribe_url
-      unsubscribe_subscription_path(url_token)
+      unsubscribe_subscription_path(params[:id])
     end
     helper_method :unsubscribe_url
-
-    private
-
-    def url_token
-      @url_token ||= CGI.escape(params[:id])
-    end
   end
 end


### PR DESCRIPTION
First of all, thanks @ankane for making this useful gem.

However, when I tried to integrate it with our app, I kept getting "subscription not found" issue. The weird part is that web page says 'Subscription not found' though, user is still correctly unsubscribed.

After spending time debugging, I found that the unescaping of params[:id] seems to be done in ActiveRecord side instead of ActionController, so in subscription controller, `params[:id]` would be already escaped, and additional escaping will result in subscription not found after redirection.

This closes #3 and probably close #6 as well.