### PR TITLE
Fix routes in Rails 4.1.2+

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,8 +3,9 @@ Rails.application.routes.draw do
 end
 
 Mailkick::Engine.routes.draw do
-  resources :subscriptions, only: [:show] do
-    get :unsubscribe, on: :member
-    get :subscribe, on: :member
+  scope format: false do
+    get '/subscriptions/*id/unsubscribe', to: "subscriptions#unsubscribe", as: :unsubscribe_subscription
+    get '/subscriptions/*id/subscribe', to: "subscriptions#subscribe", as: :subscribe_subscription
+    get '/subscriptions/*id', to: "subscriptions#show", as: :subscription
   end
 end


### PR DESCRIPTION
Hey, @ankane 
Recently we observed a weird 404 problems that mailkick paths couldn't be routed to desired controller, and found that it's caused by rails/rails#16058.

Please have a look. Thanks!
