### PR TITLE
Update migration for Rails 5

### DIFF
--- a/lib/generators/mailkick/templates/install.rb
+++ b/lib/generators/mailkick/templates/install.rb
@@ -1,4 +1,4 @@
-class <%= migration_class_name %> < ActiveRecord::Migration
+class <%= migration_class_name %> < ActiveRecord::Migration<% if ActiveRecord::VERSION::MAJOR >= 5 %>[<%=ActiveRecord::Migration.current_version%>]<% end %>
   def change
     create_table :mailkick_opt_outs do |t|
       t.string :email
@@ -7,7 +7,8 @@ class <%= migration_class_name %> < ActiveRecord::Migration
       t.boolean :active, null: false, default: true
       t.string :reason
       t.string :list
-      t.timestamps
+
+      <% if ActiveRecord::VERSION::MAJOR >= 5 || (ActiveRecord::VERSION::MAJOR >= 4 && ActiveRecord::VERSION::MINOR >= 2)%>t.timestamps null: false<% else %>t.timestamps<% end %>
     end
 
     add_index :mailkick_opt_outs, :email


### PR DESCRIPTION
This Pull Request updates migration file for Rails 5.

--

And version identifier `[5.0]` in superclass.

Ref. https://github.com/rails/rails/pull/21538

Rails 4.2 deprecates timestamp without `null: false` options.

Ref. https://github.com/rails/rails/pull/16481

Example of Generated migration with Rails 5:

```ruby
class InstallMailkick < ActiveRecord::Migration[5.0]
  def change
    create_table :mailkick_opt_outs do |t|
      t.string :email
      t.integer :user_id
      t.string :user_type
      t.boolean :active, null: false, default: true
      t.string :reason
      t.string :list

      t.timestamps null: false
    end

    add_index :mailkick_opt_outs, :email
    add_index :mailkick_opt_outs, [:user_id, :user_type]
  end
end
```

Example of Generated migration with Rails 4.2.x:

```ruby
class InstallMailkick < ActiveRecord::Migration
  def change
    create_table :mailkick_opt_outs do |t|
      t.string :email
      t.integer :user_id
      t.string :user_type
      t.boolean :active, null: false, default: true
      t.string :reason
      t.string :list

      t.timestamps null: false
    end

    add_index :mailkick_opt_outs, :email
    add_index :mailkick_opt_outs, [:user_id, :user_type]
  end
end
```