### PR TITLE
Use prepend instead of alias_method_chain

### DIFF
--- a/lib/mailkick.rb
+++ b/lib/mailkick.rb
@@ -91,5 +91,5 @@ module Mailkick
   end
 end
 
-ActionMailer::Base.send :include, Mailkick::Mailer
+ActionMailer::Base.send :prepend, Mailkick::Mailer
 ActiveRecord::Base.send(:extend, Mailkick::Model) if defined?(ActiveRecord)

--- a/lib/mailkick/mailer.rb
+++ b/lib/mailkick/mailer.rb
@@ -1,13 +1,7 @@
 module Mailkick
   module Mailer
-    def self.included(base)
-      base.class_eval do
-        alias_method_chain :mail, :mailkick
-      end
-    end
-
-    def mail_with_mailkick(headers = {}, &block)
-      message = mail_without_mailkick(headers, &block)
+    def mail(headers = {}, &block)
+      message = super(headers, &block)
 
       Mailkick::Processor.new(message).process
 


### PR DESCRIPTION
This Pull Request fixes following warning for Rails 5:

```
DEPRECATION WARNING: alias_method_chain is deprecated. Please, use
Module#prepend instead. From module, you can access the original method
using super.
```