### PR TITLE
ENV["MANDRILL_APIKEY"] => ENV["MANDRILL_API_KEY"]

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Be sure `ENV["SENDGRID_USERNAME"]` and `ENV["SENDGRID_PASSWORD"]` are set.
 gem 'mandrill-api'
 ```
 
-Be sure `ENV["MANDRILL_APIKEY"]` is set.
+Be sure `ENV["MANDRILL_API_KEY"]` is set.
 
 #### Mailchimp
 

--- a/lib/mailkick/service/mandrill.rb
+++ b/lib/mailkick/service/mandrill.rb
@@ -10,9 +10,12 @@ module Mailkick
         "unsub" => "unsubscribe"
       }
 
+      # TODO remove ENV["MANDRILL_APIKEY"]
       def initialize(options = {})
         require "mandrill"
-        @mandrill = ::Mandrill::API.new(options[:api_key] || ENV["MANDRILL_API_KEY"])
+        @mandrill = ::Mandrill::API.new(
+          options[:api_key] || ENV["MANDRILL_API_KEY"] || ENV["MANDRILL_APIKEY"]
+        )
       end
 
       # TODO paginate
@@ -26,8 +29,10 @@ module Mailkick
         end
       end
 
+      # TODO remove ENV["MANDRILL_APIKEY"]
       def self.discoverable?
-        !!(defined?(::Mandrill::API) && ENV["MANDRILL_API_KEY"])
+        !!(defined?(::Mandrill::API) &&
+          ENV["MANDRILL_API_KEY"] || ENV["MANDRILL_APIKEY"]
       end
     end
   end

--- a/lib/mailkick/service/mandrill.rb
+++ b/lib/mailkick/service/mandrill.rb
@@ -12,7 +12,7 @@ module Mailkick
 
       def initialize(options = {})
         require "mandrill"
-        @mandrill = ::Mandrill::API.new(options[:api_key] || ENV["MANDRILL_APIKEY"])
+        @mandrill = ::Mandrill::API.new(options[:api_key] || ENV["MANDRILL_API_KEY"])
       end
 
       # TODO paginate
@@ -27,7 +27,7 @@ module Mailkick
       end
 
       def self.discoverable?
-        !!(defined?(::Mandrill::API) && ENV["MANDRILL_APIKEY"])
+        !!(defined?(::Mandrill::API) && ENV["MANDRILL_API_KEY"])
       end
     end
   end

--- a/lib/mailkick/service/mandrill.rb
+++ b/lib/mailkick/service/mandrill.rb
@@ -14,7 +14,7 @@ module Mailkick
       def initialize(options = {})
         require "mandrill"
         @mandrill = ::Mandrill::API.new(
-          options[:api_key] || ENV["MANDRILL_API_KEY"] || ENV["MANDRILL_APIKEY"]
+          options[:api_key] || ENV["MANDRILL_APIKEY"] || ENV["MANDRILL_API_KEY"]
         )
       end
 
@@ -32,7 +32,7 @@ module Mailkick
       # TODO remove ENV["MANDRILL_APIKEY"]
       def self.discoverable?
         !!(defined?(::Mandrill::API) &&
-          ENV["MANDRILL_API_KEY"] || ENV["MANDRILL_APIKEY"]
+          (ENV["MANDRILL_APIKEY"] || ENV["MANDRILL_API_KEY"])
       end
     end
   end


### PR DESCRIPTION
The ENV variables for the other email services have an underscore between `API` and `KEY` such as:
`ENV["MAILCHIMP_API_KEY"]` & `ENV["MAILGUN_API_KEY"]`

It would make sense for Mandrill to be consistent.