### PR TITLE
change mailgun domain to smtp_settings[:domain] default

### DIFF
--- a/lib/mailkick/service/mailgun.rb
+++ b/lib/mailkick/service/mailgun.rb
@@ -6,7 +6,7 @@ module Mailkick
       def initialize(options = {})
         require "mailgun"
         mailgun_client = ::Mailgun::Client.new(options[:api_key] || ENV["MAILGUN_API_KEY"])
-        domain = options[:domain] || ActionMailer::Base.default_url_options[:host]
+        domain = options[:domain] || ActionMailer::Base.smtp_settings[:domain]
         @mailgun_events = ::Mailgun::Events.new(mailgun_client, domain)
       end
 


### PR DESCRIPTION
If you are using a custom domain on mailgun, then it is likely that the default url for your mailer is not the same as the domain for sending email.  This change allows the two to be different and therefore also allows Mailkick.fetch_opt_outs to work given that it requires the correct mailgun domain in order to authenticate
