### PR TITLE
Don’t try to mutate the raw_source mail part

### DIFF
--- a/lib/mailkick/processor.rb
+++ b/lib/mailkick/processor.rb
@@ -16,12 +16,18 @@ module Mailkick
       end
 
       verifier = ActiveSupport::MessageVerifier.new(Mailkick.secret_token)
-      token = verifier.generate([email, user.try(:id), user.try(:class).try(:name), list])
+      @token = verifier.generate([email, user.try(:id), user.try(:class).try(:name), list])
 
       parts = message.parts.any? ? message.parts : [message]
-      parts.each do |part|
-        part.body.raw_source.gsub!(/%7B%7BMAILKICK_TOKEN%7D%7D/, CGI.escape(token))
-      end
+
+      message.html_part = replace_token(message.html_part.decoded) if message.html_part
+      message.text_part = replace_token(message.text_part.decoded) if message.text_part
+    end
+
+    private
+
+    def replace_token(text)
+      text.gsub(/%7B%7BMAILKICK_TOKEN%7D%7D/, CGI.escape(@token))
     end
   end
 end


### PR DESCRIPTION
mail 2.6.4 and up uses frozen string literals in Ruby 2.3 and up, and raw_source
is a frozen string. Also according to the mail authors, mutating
raw_source is pretty error-prone, and not an ideal way to achieve the
token substitution.

Instead we should just gsub and then re-assign the two parts of the
message that need to include the mailkick token; the html and the text
parts.