### PR TITLE
Don’t try to mutate the raw_source mail part

### DIFF
--- a/lib/mailkick/processor.rb
+++ b/lib/mailkick/processor.rb
@@ -20,7 +20,9 @@ module Mailkick
 
       parts = message.parts.any? ? message.parts : [message]
       parts.each do |part|
-        part.body.raw_source.gsub!(/%7B%7BMAILKICK_TOKEN%7D%7D/, CGI.escape(token))
+        if part.content_type.match(/text\/(html|plain)/)
+          part.body = part.body.decoded.gsub(/%7B%7BMAILKICK_TOKEN%7D%7D/, CGI.escape(token))
+        end
       end
     end
   end


### PR DESCRIPTION
mail 2.6.4 and up (required in Rails 4.2.6) uses string literals in Ruby 2.3 and up, and raw_source
is a frozen string. Also according to the mail authors, mutating
raw_source is pretty error-prone, and not an ideal way to achieve the
token substitution.

Instead we should firstly ensure we’re only gsubbing the html/plain
parts of the email, and secondly re-assign rather than mutate the body
parts.
