### PR TITLE
Improve documentation: Add `How to access the mailkick table`

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,22 +203,7 @@ Resubscribe
 user.opt_in
 ```
 
-## Accessing the Mailkick Table
-
-By default, the underlying table where mailkick stores the data is named `mailkick_opt_outs`.
-
-This is also exposed as a Rails model with class name `Mailkick::OptOut`
-
-If you want to access the Mailkick data, to bulk update a list name or for debugging purposes,
-you can do so using this class.
-
-For eg,
-
-To bulk update a list's name:
-
-```ruby
-Mailkick::OptOut.where(list: 'old_list_name').update_all(list: 'new_list_name')
-```
+You can access Mailkick data using the model `Mailkick::OptOut`
 
 ## History
 

--- a/README.md
+++ b/README.md
@@ -203,6 +203,30 @@ Resubscribe
 user.opt_in
 ```
 
+## Accessing the Mailkick Table
+
+By default, the underlying table where mailkick stores the data is named `mailkick_opt_outs`.
+
+However, this table is not exposed as a Rails model.
+
+In case you want to access this table the Rails-y way, to bulk update a list name or for debugging purposes,
+simply add this in your Rails console or migration file.
+
+So like,
+
+```ruby
+class MailkickOptOut < ActiveRecord::Base; end;
+```
+and you can start accessing the data in this table via the class `MailkickOptOut`
+
+For eg,
+
+To bulk update a list's name:
+
+```ruby
+MailkickOptOut.where(list: 'old_list_name').update_all(list: 'new_list_name')
+```
+
 ## History
 
 View the [changelog](https://github.com/ankane/mailkick/blob/master/CHANGELOG.md)

--- a/README.md
+++ b/README.md
@@ -207,24 +207,17 @@ user.opt_in
 
 By default, the underlying table where mailkick stores the data is named `mailkick_opt_outs`.
 
-However, this table is not exposed as a Rails model.
+This is also exposed as a Rails model with class name `Mailkick::OptOut`
 
-In case you want to access this table the Rails-y way, to bulk update a list name or for debugging purposes,
-simply add this in your Rails console or migration file.
-
-So like,
-
-```ruby
-class MailkickOptOut < ActiveRecord::Base; end;
-```
-and you can start accessing the data in this table via the class `MailkickOptOut`
+If you want to access the Mailkick data, to bulk update a list name or for debugging purposes,
+you can do so using this class.
 
 For eg,
 
 To bulk update a list's name:
 
 ```ruby
-MailkickOptOut.where(list: 'old_list_name').update_all(list: 'new_list_name')
+Mailkick::OptOut.where(list: 'old_list_name').update_all(list: 'new_list_name')
 ```
 
 ## History


### PR DESCRIPTION
I am adding this to include information that could have benefited me, but was found missing in the documentation.

I had to mass update the existing list names and since `mailkick_opt_outs` is not exposed as a model, I thought the only way to do this was via raw SQL.

But turns out that simply opening a class with the same name which inherits from `ActiveRecord::Base` works and now mass updates, searching data for debugging etc are much more easier.

I have added this information. Hope it benefits somebody :)

UPDATE: Mailkick already exposes data via `Mailkick::OptOut`, updated docs to use this class