### PR TITLE
Changed self.class.name to self.name for correct opted_out result

### DIFF
--- a/lib/mailkick/model.rb
+++ b/lib/mailkick/model.rb
@@ -4,7 +4,7 @@ module Mailkick
       email_key = opts[:email_key] || :email
       class_eval do
         scope :opted_out, lambda { |options = {}|
-          binds = [self.class.name, true]
+          binds = [self.name, true]
           if options[:list]
             query = "(mailkick_opt_outs.list IS NULL OR mailkick_opt_outs.list = ?)"
             binds << options[:list]


### PR DESCRIPTION
The scope `opted_out` includes this statement `binds = [self.class.name, true]` which causes the wrong SQL query to be generated.
````
[1] pry(main)> User.opted_out.count
   (1.8ms)  SELECT COUNT(*) FROM "users" WHERE (EXISTS(SELECT * FROM mailkick_opt_outs WHERE (users.email = mailkick_opt_outs.email OR (users.id = mailkick_opt_outs.user_id AND mailkick_opt_outs.user_type = 'ActiveRecord::Relation')) AND mailkick_opt_outs.active = TRUE AND mailkick_opt_outs.list IS NULL))
=> 0
````
Fixing the statement to `binds = [self.class.name, true]` shows the correct SQL statement. We are looking for user_type to be `User`.
````
[1] pry(main)> User.opted_out.count
   (1.8ms)  SELECT COUNT(*) FROM "users" WHERE (EXISTS(SELECT * FROM mailkick_opt_outs WHERE (users.email = mailkick_opt_outs.email OR (users.id = mailkick_opt_outs.user_id AND mailkick_opt_outs.user_type = 'User')) AND mailkick_opt_outs.active = TRUE AND mailkick_opt_outs.list IS NULL))
=> 2
````