### PR TITLE
Improve support with Blind Index on opt_outs

### DIFF
--- a/test/mailkick_test.rb
+++ b/test/mailkick_test.rb
@@ -32,6 +32,48 @@ class MailkickTest < Minitest::Test
     assert_equal 0, User.not_opted_out.count
   end
 
+  def test_opt_outs
+    user1 = User.create!(email: 'user1@example.org')
+    user2 = User.create!(email: 'user2@example.org')
+    user3 = User.create!(email: 'user3@example.org')
+    user4 = User.create!(email: 'user4@example.org')
+
+    Mailkick.opt_out(email: user1.email, user: user1)
+    Mailkick.opt_out(email: 'other2@example.org', user: user2)
+    Mailkick.opt_out(email: 'other3@example.org')
+    Mailkick.opt_out(user: user3)
+
+    opt_outs = Mailkick.opt_outs
+    assert_equal 4, opt_outs.size
+
+    opt_outs = Mailkick.opt_outs(email: user1.email)
+    assert_equal 1, opt_outs.size
+
+    opt_outs = Mailkick.opt_outs(email: user2.email)
+    assert_equal 0, opt_outs.size
+
+    opt_outs = Mailkick.opt_outs(email: 'other2@example.org')
+    assert_equal 1, opt_outs.size
+
+    opt_outs = Mailkick.opt_outs(user: user2)
+    assert_equal 1, opt_outs.size
+
+    opt_outs = Mailkick.opt_outs(email: user2.email, user: user2)
+    assert_equal 1, opt_outs.size
+
+    opt_outs = Mailkick.opt_outs(email: 'other3@example.org', user: user2)
+    assert_equal 2, opt_outs.size
+
+    opt_outs = Mailkick.opt_outs(user: user3)
+    assert_equal 1, opt_outs.size
+
+    opt_outs = Mailkick.opt_outs(email: 'other4@example.org')
+    assert_equal 0, opt_outs.size
+
+    opt_outs = Mailkick.opt_outs(user: user4)
+    assert_equal 0, opt_outs.size
+  end
+
   def test_user_opted_out_scope
     user = User.create!
     user.opt_out


### PR DESCRIPTION
I'm trying out Mailkick with Lockbox and Blind Index and I've noticed that it breaks when trying to opt out a user because it relies on a fixed `email` field. I've updated it to pass it down as a hash in order to have Blind Index do its magic and convert it to `email_bidx`.

I've also added an extra test which should take care of checking all cases.

```
irb(main):001:0> Mailkick.opt_outs
  Mailkick::OptOut Load (2.0ms)  SELECT "mailkick_opt_outs".* FROM "mailkick_opt_outs" WHERE "mailkick_opt_outs"."active" = $1 AND (list IS NULL) LIMIT $2  [["active", true], ["LIMIT", 11]]
=> #<ActiveRecord::Relation []>

irb(main):002:0> Mailkick.opt_outs email: 'test@example.com'
  Mailkick::OptOut Load (2.4ms)  SELECT "mailkick_opt_outs".* FROM "mailkick_opt_outs" WHERE "mailkick_opt_outs"."active" = $1 AND "mailkick_opt_outs"."email_bidx" = $2 AND (list IS NULL) LIMIT $3  [["active", true], ["email_bidx", "0VsENwQLv1qW1UUZrn90e6kd7TUH/QBrmTNzavPhoSY="], ["LIMIT", 11]]
=> #<ActiveRecord::Relation []>

irb(main):003:0> Mailkick.opt_outs email: 'test@example.com', user: User.first
  User Load (1.7ms)  SELECT "users".* FROM "users" ORDER BY "users"."id" ASC LIMIT $1  [["LIMIT", 1]]
  Mailkick::OptOut Load (1.3ms)  SELECT "mailkick_opt_outs".* FROM "mailkick_opt_outs" WHERE "mailkick_opt_outs"."active" = $1 AND ("mailkick_opt_outs"."email_bidx" = $2 OR "mailkick_opt_outs"."user_type" = $3 AND "mailkick_opt_outs"."user_id" = $4) AND (list IS NULL) LIMIT $5  [["active", true], ["email_bidx", "0VsENwQLv1qW1UUZrn90e6kd7TUH/QBrmTNzavPhoSY="], ["user_type", "User"], ["user_id", 1], ["LIMIT", 11]]
=> #<ActiveRecord::Relation []>

irb(main):004:0> Mailkick.opt_outs user: User.first
  User Load (1.2ms)  SELECT "users".* FROM "users" ORDER BY "users"."id" ASC LIMIT $1  [["LIMIT", 1]]
  Mailkick::OptOut Load (1.0ms)  SELECT "mailkick_opt_outs".* FROM "mailkick_opt_outs" WHERE "mailkick_opt_outs"."active" = $1 AND "mailkick_opt_outs"."user_type" = $2 AND "mailkick_opt_outs"."user_id" = $3 AND (list IS NULL) LIMIT $4  [["active", true], ["user_type", "User"], ["user_id", 1], ["LIMIT", 11]]
=> #<ActiveRecord::Relation []>

irb(main):005:0> Mailkick.opt_outs email: 'test@example.com', user: User.first, list: 'test'
  User Load (1.1ms)  SELECT "users".* FROM "users" ORDER BY "users"."id" ASC LIMIT $1  [["LIMIT", 1]]
  Mailkick::OptOut Load (1.4ms)  SELECT "mailkick_opt_outs".* FROM "mailkick_opt_outs" WHERE "mailkick_opt_outs"."active" = $1 AND ("mailkick_opt_outs"."email_bidx" = $2 OR "mailkick_opt_outs"."user_type" = $3 AND "mailkick_opt_outs"."user_id" = $4) AND (list IS NULL OR list = 'test') LIMIT $5  [["active", true], ["email_bidx", "0VsENwQLv1qW1UUZrn90e6kd7TUH/QBrmTNzavPhoSY="], ["user_type", "User"], ["user_id", 1], ["LIMIT", 11]]
=> #<ActiveRecord::Relation []>
```