### PR TITLE
Use app.message_verifier to derive verifier from secret_key_base

### DIFF
--- a/lib/mailkick.rb
+++ b/lib/mailkick.rb
@@ -22,7 +22,11 @@ require "mailkick/version"
 require "mailkick/engine" if defined?(Rails)
 
 module Mailkick
-  mattr_accessor :services, :secret_token, :mount, :process_opt_outs_method
+  mattr_accessor :services, :message_verifier, :mount, :process_opt_outs_method
+
+  # Deprecated
+  mattr_accessor :secret_token
+
   self.services = []
   self.mount = true
   self.process_opt_outs_method = ->(_) { raise "process_opt_outs_method not defined" }
@@ -35,10 +39,6 @@ module Mailkick
     Service.subclasses.each do |service|
       services << service.new if service.discoverable?
     end
-  end
-
-  def self.message_verifier
-    @message_verifier ||= ActiveSupport::MessageVerifier.new(Mailkick.secret_token)
   end
 
   def self.generate_token(subscriber, list)

--- a/lib/mailkick/engine.rb
+++ b/lib/mailkick/engine.rb
@@ -5,6 +5,9 @@ module Mailkick
     initializer "mailkick" do |app|
       Mailkick.discover_services unless Mailkick.services.any?
 
+      Mailkick.message_verifier ||= app.message_verifier('mailkick')
+
+      # Deprecated: look up secret_key_base
       Mailkick.secret_token ||= begin
         creds =
           if app.respond_to?(:credentials) && app.credentials.secret_key_base
@@ -17,6 +20,9 @@ module Mailkick
 
         creds.respond_to?(:secret_key_base) ? creds.secret_key_base : creds.secret_token
       end
+
+      # Use deprecated secret to verify messages
+      Mailkick.message_verifier.rotate Mailkick.secret_token
     end
   end
 end


### PR DESCRIPTION
`secret_key_base` should not be used directly in a message verifier, but should be used to derive a new key. Since Rails ~4 there has been [`Application#message_verifier`](https://api.rubyonrails.org/classes/Rails/Application.html#method-i-message_verifier), which will create a verifier with a key derived from `secret_key_base` and the name of the verifier.

This replaces Mailkick's message verify with one returned from `app.message_verifier('mailkick')`. It adds the deprecated `Mailkick.secret_token` as a [rotated key](https://api.rubyonrails.org/classes/ActiveSupport/MessageVerifier.html#class-ActiveSupport::MessageVerifier-label-Rotating+keys) so old links continue to work.