### PR TITLE
Fix for assets:environment rake task when SECRET_KEY_BASE_DUMMY=1

### DIFF
--- a/lib/mailkick/engine.rb
+++ b/lib/mailkick/engine.rb
@@ -13,7 +13,7 @@ module Mailkick
         creds =
           if app.respond_to?(:credentials) && app.credentials.secret_key_base
             app.credentials
-          elsif app.respond_to?(:secrets)
+          elsif app.respond_to?(:secrets) && app.secrets.secret_key_base
             app.secrets
           else
             app.config


### PR DESCRIPTION
Rails 7.1.0.beta1 introduced a new Dockerfile that includes this line:
```
# Precompiling assets for production without requiring secret RAILS_MASTER_KEY
RUN SECRET_KEY_BASE_DUMMY=1 ./bin/rails assets:precompile
```
which results in this output when run without setting RAILS_MASTER_KEY:
```
** Invoke assets:precompile (first_time)
** Invoke assets:environment (first_time)
** Execute assets:environment
** Invoke environment (first_time)
** Execute environment
bin/rails aborted!
ArgumentError: Secret should not be nil.
```

A modern spin on #37?

The change implemented in this PR proposes an additional guard for cases where `app.secrets.secret_key_base` is `nil`.

Happy to discuss further and would appreciate your guidance if this is a red herring and the underlying cause is user error.